### PR TITLE
fix(cmd/agent.go): Don't force timescale for non-standalone mode.

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -83,11 +83,6 @@ to run in a standalone mode where it does not run any GRPC server.`,
 			if conf.Interval <= 0 {
 				conf.Interval = defaultAgentInterval
 			}
-
-			if !conf.Standalone {
-				// enforce timescale metrics for non-standalone mode
-				conf.Metrics.Backend = defaultAgentExporter
-			}
 		},
 		Run: func(*cobra.Command, []string) {
 			if err := agent.Run(ctx, &conf); err != nil {


### PR DESCRIPTION
Since we are flexible with using many databases for storing
metrics both in standalone and non-standalone mode, removing these
lines does not enforce using timescale for when using the agent
along-with the application (which was previously the case).

Fixes #68 