### PR TITLE
influxdb: Fix query for collecting metrics.

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -23,6 +23,7 @@ const (
 	defaultAgentMetricsPort     uint16 = 5432
 	defaultAgentMetricsUsername        = ""
 	defaultAgentMetricsPassword        = ""
+	defaultAgentMetricsOrgName         = ""
 	defaultAgentMetricsDBName          = ""
 	defaultAgentMetricsSSLMode         = true
 	defaultAgentPageDeploy             = false
@@ -55,6 +56,8 @@ const (
 	flagAgentConfigMetricsUsername    = "metrics-username"
 	keyAgentConfigMetricsPassword     = "metrics.password"
 	flagAgentConfigMetricsPassword    = "metrics-password"
+	keyAgentConfigMetricsOrgName      = "metrics.org_name"
+	flagAgentConfigMetricsOrgName     = "metrics-org-name"
 	keyAgentConfigMetricsDBName       = "metrics.db_name"
 	flagAgentConfigMetricsDBName      = "metrics-db-name"
 	keyAgentConfigMetricsSSLMode      = "metrics.ssl_mode"
@@ -124,6 +127,7 @@ to run in a standalone mode where it does not run any GRPC server.`,
 	cmd.Flags().Uint16(flagAgentConfigMetricsPort, defaultAgentMetricsPort, "port to run metrics server on")
 	cmd.Flags().String(flagAgentConfigMetricsUsername, defaultAgentMetricsUsername, "username credential for metrics")
 	cmd.Flags().String(flagAgentConfigMetricsPassword, defaultAgentMetricsPassword, "password credential for metrics")
+	cmd.Flags().String(flagAgentConfigMetricsOrgName, defaultAgentMetricsOrgName, "organization name for metrics")
 	cmd.Flags().String(flagAgentConfigMetricsDBName, defaultAgentMetricsDBName, "database name for metrics")
 	cmd.Flags().Bool(flagAgentConfigMetricsSSLMode, defaultAgentMetricsSSLMode, "whether to run metrics with SSL")
 	cmd.Flags().Duration(
@@ -146,6 +150,7 @@ to run in a standalone mode where it does not run any GRPC server.`,
 		keyAgentConfigMetricsPort:        flagAgentConfigMetricsPort,
 		keyAgentConfigMetricsUsername:    flagAgentConfigMetricsUsername,
 		keyAgentConfigMetricsPassword:    flagAgentConfigMetricsPassword,
+		keyAgentConfigMetricsOrgName:     flagAgentConfigMetricsOrgName,
 		keyAgentConfigMetricsDBName:      flagAgentConfigMetricsDBName,
 		keyAgentConfigMetricsSSLMode:     flagAgentConfigMetricsSSLMode,
 		keyAgentConfigInterval:           flagAgentConfigInterval,

--- a/pkg/components/agent/agent.go
+++ b/pkg/components/agent/agent.go
@@ -118,6 +118,7 @@ func initExportAndAlerts(
 		Name:     "metrics_export_and_alert",
 		Interval: interval,
 		Func: func(c context.Context) (interface{}, error) {
+			ctx.Logger().Infoln("exporting metrics")
 			stats := manager.PullAllStats()
 			var (
 				exportMetrics []checker.Metric

--- a/pkg/config/metrics.go
+++ b/pkg/config/metrics.go
@@ -56,6 +56,7 @@ type MetricsProvider struct {
 	Backend  string `mapstructure:"backend" json:"backend"`
 	Host     string `mapstructure:"host" json:"host"`
 	Port     uint16 `mapstructure:"port" json:"port"`
+	OrgName  string `mapstructure:"org_name" json:"org_name"`
 	DBName   string `mapstructure:"db_name" json:"db_name"`
 	Username string `mapstructure:"username" json:"username"`
 	Password string `mapstructure:"password" json:"password"`
@@ -75,6 +76,11 @@ func (m *MetricsProvider) GetHost() string {
 // GetPort returns the port of the database provider.
 func (m *MetricsProvider) GetPort() uint16 {
 	return m.Port
+}
+
+// GetOrgName returns the organization name of the provider.
+func (m *MetricsProvider) GetOrgName() string {
+	return m.OrgName
 }
 
 // GetDBName returns the database name of the provider.

--- a/pkg/exporter/influxdb/doc.go
+++ b/pkg/exporter/influxdb/doc.go
@@ -1,6 +1,2 @@
-// Copyright (c) 2020 SDSLabs
-// Use of this source code is governed by an MIT license
-// details of which can be found in the LICENSE file.
-
 // Package influxdb implements the influxdb exporter.
 package influxdb

--- a/pkg/exporter/provider.go
+++ b/pkg/exporter/provider.go
@@ -7,6 +7,7 @@ type Provider interface {
 
 	GetHost() string     // Returns the host.
 	GetPort() uint16     // Returns the port.
+	GetOrgName() string  // Returns the organization name.
 	GetDBName() string   // Returns the database name.
 	GetUsername() string // Returns the username.
 	GetPassword() string // Returns the password.

--- a/pkg/plugins/exporters.go
+++ b/pkg/plugins/exporters.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	// Register all the metrics exporters here.
+	_ "github.com/sdslabs/pinger/pkg/exporter/influxdb"
 	_ "github.com/sdslabs/pinger/pkg/exporter/log"
 	_ "github.com/sdslabs/pinger/pkg/exporter/timescale"
 )

--- a/pkg/util/appcontext/context.go
+++ b/pkg/util/appcontext/context.go
@@ -64,6 +64,7 @@ func Background() *Context {
 func BackgroundDebug() *Context {
 	ctx := Background()
 	ctx.debug = true
+	ctx.log.SetLevel(logrus.DebugLevel)
 	return ctx
 }
 


### PR DESCRIPTION
Previously the regex to match all the IDs matched any char
and not the complete word, limited by start and end. For
example: if check IDs were "abc" and "def", it matched all
the characters from 'a' to 'f'. This behaviour is fixed by
updating the regex to only select the check IDs that are
provided to us. This match is exact and literal.

Fixes #90

Signed-off-by: Vaibhav <vrongmeal@gmail.com>