### PR TITLE
util: Move `metrics.go` into its own package.

### DIFF
--- a/pkg/components/agent/page.go
+++ b/pkg/components/agent/page.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/sdslabs/pinger/pkg/config/configfile"
 	"github.com/sdslabs/pinger/pkg/exporter"
-	"github.com/sdslabs/pinger/pkg/util"
 	"github.com/sdslabs/pinger/pkg/util/appcontext"
 	"github.com/sdslabs/pinger/pkg/util/controller"
 	"github.com/sdslabs/pinger/pkg/util/httpserver"
+	metricsutil "github.com/sdslabs/pinger/pkg/util/metrics"
 	"github.com/sdslabs/pinger/pkg/util/static"
 )
 
@@ -201,6 +201,6 @@ func addMetricsRoute(
 			return
 		}
 
-		httpserver.RespondOK(ctx, c, util.PrepareMetricsResponse(batches, metrics))
+		httpserver.RespondOK(ctx, c, metricsutil.PrepareMetricsResponse(batches, metrics))
 	})
 }

--- a/pkg/util/metrics/doc.go
+++ b/pkg/util/metrics/doc.go
@@ -1,0 +1,4 @@
+/*
+Package metrics contains utilities for handling status metrics.
+*/
+package metrics

--- a/pkg/util/metrics/serialize.go
+++ b/pkg/util/metrics/serialize.go
@@ -1,4 +1,4 @@
-package util
+package metrics
 
 import (
 	"time"


### PR DESCRIPTION
In our packaging style we do follow layering of packages.
Currently, util package depends on other util/* packages.
Hence, either the dependencies should move into util
independently OR we should move metrics.go into another
package util/metrics. The latter is done since the former
changes multiple other packages and those changes do not make
sense.

Fixes #95

Signed-off-by: Vaibhav <vrongmeal@gmail.com>