### PR TITLE
docs: Fix format command.

### DIFF
--- a/docs/src/contributing/pull-request.md
+++ b/docs/src/contributing/pull-request.md
@@ -33,7 +33,7 @@ all the errors that might be resolved automatically.
 # To check for linting errors
 $ make lint
 # To fix auto-fixable errors
-$ make format
+$ make fmt
 ```
 
 ### Other checks


### PR DESCRIPTION
Updated docs/src/contributing/pull-request.md which listed
the format command as `make format` whereas it's actually
`make fmt`.

Fixes #94

Signed-off-by: Vaibhav <vrongmeal@gmail.com>